### PR TITLE
Strawtubes digi

### DIFF
--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -714,18 +714,19 @@ class ShipDigiReco:
    from strawDigi_conf import DriftTimeCalculate as dtc
 
    # turn on Drift time part or not, or using default setting
+   # true = using constant drift velocity (default way)
    ROOT.strawtubesDigi.Instance().UseDefaultDriftTime(dtc.defaultDriftTime)
 
    # misalign part
-   beingInit = ROOT.strawtubesDigi.Instance().IsInitialized()
+   beingInit = ROOT.strawtubesDigi.Instance().IsInitialized() #digitize will be called in loop, prevent initialize again
    if (stm.misalign and (not beingInit)):
      ROOT.strawtubesDigi.Instance().PassRadius(ShipGeo.strawtubes.InnerStrawDiameter/2.)
      ROOT.strawtubesDigi.Instance().SetDebug(stm.debug)
-     if stm.randType == "None":
+     if stm.randType == "None":		# no distribution
        ROOT.strawtubesDigi.Instance().SetSameSagging(stm.maxTubeSagging, stm.maxWireSagging)
-     elif stm.randType == "Gaus":
+     elif stm.randType == "Gaus":	# gaussian, not implemented well
        ROOT.strawtubesDigi.Instance().SetGausSagging(stm.maxTubeSagging, stm.tubeGausSigma, stm.maxWireSagging, stm.wireGausSigma)
-     elif stm.randType == "Unif":
+     elif stm.randType == "Unif":	# uniform distribution
        ROOT.strawtubesDigi.Instance().SetUnifSagging(stm.maxTubeSagging, stm.tubeUnifDelta, stm.maxWireSagging, stm.wireUnifDelta)
      else:
        print "Not a proper type of distribution for strawtube sagging"
@@ -792,9 +793,9 @@ class ShipDigiReco:
 
      # use true t0  construction: 
      #     fdigi = t0 + p->GetTime() + t_drift + ( stop[0]-p->GetX() )/ speedOfLight;
-     if (ROOT.strawtubesDigi.Instance().IsDefaultDriftTime()):
+     if (ROOT.strawtubesDigi.Instance().IsDefaultDriftTime()):	# using drift velocity calculation
          smear = (aDigi.GetDigi() - self.sTree.t0  - p.GetTime() - ( stop[0]-p.GetX() )/ u.speedOfLight) * v_drift
-     else:
+     else:	# for the updated drift time calculation method
          aHit = ROOT.strawtubesHit(p,self.sTree.t0)
          TDC = aHit.GetTDC()
          t0 = self.sTree.t0 + p.GetTime()

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -97,6 +97,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
       print "no fieldmap given, geofile too old, not anymore support"
       exit(-1)
     sGeo   = fgeo.FAIRGeom
+    # this 2 lines are not used, muted to avoid error 
     #geoMat =  ROOT.genfit.TGeoMaterialInterface()
     #ROOT.genfit.MaterialEffects.getInstance().init(geoMat)
     bfield = ROOT.genfit.FairShipFields()
@@ -1038,7 +1039,7 @@ def init_book_hist():
     ut.bookHist(h,'massfittedtracks','mass fitted tracks',210,-0.005,0.205)
     ut.bookHist(h,'pvspfitted','p-patrec vs p-fitted',401,-200.5,200.5,401,-200.5,200.5)
 
-
+    # added serval graph
     ut.bookHist(h,'abs(x - x-true)','Hits abs(x - x-true)',260,-0.05,5.05)
     ut.bookHist(h,'abs(y - y-true)','Hits abs(y - y-true)',260,-0.05,5.05)
     ut.bookHist(h,'abs(x - x-true)_12','Hits abs(x - x-true)',260,-0.05,5.05)

--- a/python/strawDigi_conf.py
+++ b/python/strawDigi_conf.py
@@ -2,12 +2,12 @@ import shipunit as u
 
 class StrawtubesMisalign:
     # TurnOn the module of misalign or no
-    misalign = False
+    misalign = True
     # rand type : "None", "Gaus", "Unif", may added more, need modify strawtubeDigi
     # "None" = all tubes have same maximum sagging, no distribution of max. sag
     # "Gaus" = the tubes have different max sagging with gaus distribution
     # "Unif" = the different max sagging is uniformly distributed in a range given range, not the same as "None"
-    randType = "None"
+    randType = "Unif"
 
     # maximum sagging at the middle of the tube
     # for using distribution, these are mean value /mpv /something like that
@@ -25,7 +25,8 @@ class StrawtubesMisalign:
     # debug or not
     debug = False
 
+# Using which way to calculate drift time
 class DriftTimeCalculate:
-    defaultDriftTime = True
+    defaultDriftTime = True   # true for using drift velocity (default)
 
 

--- a/strawtubes/strawtubesDigi.cxx
+++ b/strawtubes/strawtubesDigi.cxx
@@ -259,7 +259,19 @@ Double_t strawtubesDigi::FindMisalignDist2Wire(TVector3 pPos, TVector3 start, TV
     result = TMath::Min(result, pFromEnd.Mag());
     return result;
 
-    // Another method, by using TF1 to find inverse function and minimize
+    // Another method, by using TF1 to find inverse function and minimize, not finished, cannot run
+    /*
+    TF1* dist2Wire2 = new TF1("dist2Wire2", "TMath::Sq([0] - x)+TMath::Sq([1]-strawtubesDigi::FindWireShift(x, [2], [3], [4]))", 0, 1);
+    dist2Wire2->SetParameter(0, pPos.x());
+    dist2Wire2->SetParameter(1, pPos.y());
+    dist2Wire2->SetParameter(2, start.x());
+    dist2Wire2->SetParameter(3, stop.x());
+    dist2Wire2->SetParameter(4, ID);
+    dist2Wire2->SetRange(start.x(), stop.x());
+    Double_t result = dist2Wire2->GetMinimum() + TMath::Sq(pPos.z() - start.z());
+    delete dist2Wire2;
+    return TMath::Sqrt(result);
+*/
 }
 
 Double_t strawtubesDigi::FindMisalignDist2Wire(strawtubesPoint* p)

--- a/strawtubes/strawtubesDigi.h
+++ b/strawtubes/strawtubesDigi.h
@@ -10,6 +10,8 @@
 #include "strawtubesPoint.h"
 #include "strawtubes.h"
 
+// def a enum for the type of distribution used
+// just for convinence
 enum RANDTYPE{None, Gaus, Unif};
 typedef enum RANDTYPE RandType;
 
@@ -38,19 +40,19 @@ class strawtubesDigi {
     // to set the parameter of misalignment
     void PassRadius(Double_t r) {tubeRadius = r;};
     void SetDebug(bool debugFlag) {debug = debugFlag;};
-    void SetSameSagging(Double_t inMaxTubeSagging, Double_t inMaxWireSagging);
-    void SetGausSagging(Double_t inMaxTubeSagging, Double_t inTubeGausSigma, Double_t inMaxWireSagging, Double_t inWireGausSigma);
-    void SetUnifSagging(Double_t inMaxTubeSagging, Double_t inTubeUnifDelta, Double_t inMaxWireSagging, Double_t inWireUnifDelta);
-    bool CheckInTube(TVector3 pPos, TVector3 start, TVector3 stop, Float_t ID);
-    Double_t FindMisalignDist2Wire(TVector3 pPos, TVector3 start, TVector3 stop, Float_t ID);
-    Double_t FindMisalignDist2Wire(strawtubesPoint* p);
-    bool InSmallerSection(TVector3 pPos, TVector3 start, TVector3 stop, Float_t ID);
+    void SetSameSagging(Double_t inMaxTubeSagging, Double_t inMaxWireSagging);	// initialize, the setting be same sagging for all tube
+    void SetGausSagging(Double_t inMaxTubeSagging, Double_t inTubeGausSigma, Double_t inMaxWireSagging, Double_t inWireGausSigma);	//initialize, the sagging will have a gaussian distribtion, not well implemented
+    void SetUnifSagging(Double_t inMaxTubeSagging, Double_t inTubeUnifDelta, Double_t inMaxWireSagging, Double_t inWireUnifDelta);	// initialize, the saging will have a uniform distribution
+    bool CheckInTube(TVector3 pPos, TVector3 start, TVector3 stop, Float_t ID); // check a given is in tube or not
+    Double_t FindMisalignDist2Wire(TVector3 pPos, TVector3 start, TVector3 stop, Float_t ID); // find dist2wire base on sagging 
+    Double_t FindMisalignDist2Wire(strawtubesPoint* p);	//same as above, but input parameter is a point
+    bool InSmallerSection(TVector3 pPos, TVector3 start, TVector3 stop, Float_t ID); // check the point is in which section
     bool IsMisalign() { return misalign;}
     bool IsInitialized() { return beingInit;}
 
-    // old version
-    void InitializeMisalign(Double_t tubeSag, Double_t wireSag, Double_t r, bool inDebug); 
-    void InitializeMisalign(Double_t tubeMean, Double_t tubeSigma, Double_t wireSigma, Double_t wireMean, Double_t r, bool inDebug); 
+    // old version, initialize by one line
+    void InitializeMisalign(Double_t tubeSag, Double_t wireSag, Double_t r, bool inDebug); // no distribution case
+    void InitializeMisalign(Double_t tubeMean, Double_t tubeSigma, Double_t wireSigma, Double_t wireMean, Double_t r, bool inDebug); // gaussian case, not well implemented 
 
     Double_t GetWireOffset(Float_t ID);
 
@@ -84,25 +86,25 @@ class strawtubesDigi {
     void parabolaChainsEstimation(Double_t wireOffset);
 
     // Misalignment part
-    Double_t tubeRadius = 1.0;
-    Double_t maxTubeSagging = 0.0;
-    Double_t maxWireSagging = 0.0;
-    Double_t tubeGausSigma = 0.0;
-    Double_t wireGausSigma = 0.0;
-    Double_t tubeUnifDelta = 0.0;
-    Double_t wireUnifDelta = 0.0;
-    std::map<Float_t, Double_t> tubeSaggingMap;
-    std::map<Float_t, Double_t> wireSaggingMap;
-    bool misalign = false;
-    RandType randType = None;
-    bool debug = false;
-    bool beingInit = false;
+    Double_t tubeRadius = 1.0;		// the tube radius, used to check in tube or not
+    Double_t maxTubeSagging = 0.0;	// maximum sagging of tubes, mean value/mpv if distribution is used
+    Double_t maxWireSagging = 0.0;	// as above, but for wire
+    Double_t tubeGausSigma = 0.0;	// for gaussain used, sigma for tube
+    Double_t wireGausSigma = 0.0;	// as above, for wire
+    Double_t tubeUnifDelta = 0.0;	// for uniform distribution, delta is half of the range
+    Double_t wireUnifDelta = 0.0;	// as above, for wire
+    std::map<Float_t, Double_t> tubeSaggingMap;	// a map store the maximum sagging for each strawtube, with key as straw ID
+    std::map<Float_t, Double_t> wireSaggingMap;	// as above, for wire
+    bool misalign = false;		// Is misalignment is used or not
+    RandType randType = None;		// the type of distribution
+    bool debug = false;			// a flag to turn on debug or not
+    bool beingInit = false;		// since the initialze funciton will be called in loop, avoid initlaize again
 
-    Double_t FindTubeShift(Double_t x, Double_t startx, Double_t stopx, Float_t ID);
-    Double_t FindWireShift(Double_t x, Double_t startx, Double_t stopx, Float_t ID);
-    Double_t GetMaxTubeSagging(Float_t ID);
-    Double_t GetMaxWireSagging(Float_t ID);
-    Double_t FindWireSlope(Double_t x, TVector3 start, TVector3 stop, Float_t ID);
+    Double_t FindTubeShift(Double_t x, Double_t startx, Double_t stopx, Float_t ID);	// find the shift at a given x
+    Double_t FindWireShift(Double_t x, Double_t startx, Double_t stopx, Float_t ID);	// as above, for wire
+    Double_t GetMaxTubeSagging(Float_t ID);						// get the value of max. sagging from map
+    Double_t GetMaxWireSagging(Float_t ID);						// as above, for wire
+    Double_t FindWireSlope(Double_t x, TVector3 start, TVector3 stop, Float_t ID);	// find the slope of the wire, for better linearlized approximation calculation
 
 };
 

--- a/strawtubes/strawtubesHit.cxx
+++ b/strawtubes/strawtubesHit.cxx
@@ -44,6 +44,7 @@ strawtubesHit::strawtubesHit(strawtubesPoint* p, Double_t t0)
      flag = false;
      Double_t dist2Wire;
      TVector3 pPos;
+     // calculate dist2Wire with  misalign or not
      if (strawtubesDigi::Instance().IsMisalign())
      {
         pPos = TVector3(p->GetX(), p->GetY(), p->GetZ());
@@ -59,8 +60,11 @@ strawtubesHit::strawtubesHit(strawtubesPoint* p, Double_t t0)
         dist2Wire = p->dist2Wire();
      }
 
+     // if the hit is vaild (still inside the tube)
      if (flag)
      {
+        // use which way calculate the drift time
+        // default is used for invistigate sagging only
         if (strawtubesDigi::Instance().IsDefaultDriftTime())
         {
             driftTime = fabs( gRandom->Gaus( dist2Wire, sigma_spatial ) )/v_drift;


### PR DESCRIPTION
I believe this cannot automatically merge because of a lot of update you have made. Mostly, I don't change much in my part. The calculation of misaligned dist2wire is changed. Calculation will now consider the slope also for better approximation. You may change this. But seems the result is not differ much as the slope is small. I forgot which parts are also changed since last merge, maybe the way to initialize in shipDigiReco is changed?

Since I am not good at ROOT, I failed using the TF1 to help me numerically solve the dist2Wire. If you like, you may try using ROOT to do the minimization of dr^2 as a function of x. It is a better way as it can be applied to any type of function.

Comments are added. So, maybe you just need to merge the useful thing manually by copy and paste (not using the github merge)